### PR TITLE
Pipe appropriate data directly into yielded components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /bower_components
 
 # misc
+.idea/
 /.sass-cache
 /connect.lock
 /coverage/*

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ The basic idea is that the `tri-state` component accepts an action (or actions) 
   {{/tri.loading.component}}
 
   // Rendered if the request is rejected
-  {{#tri.error.component}}
-    <p>An error occurred: {{tri.error.data.message}}</p>
+  {{#tri.error.component as |error|}}
+    <p>An error occurred: {{error.message}}</p>
   {{/tri.error.component}}
 
   // Rendered if the request resolves successfully
-  {{#tri.success.component}}
-    {{#each tri.success.data as |post|}}
+  {{#tri.success.component as |posts|}}
+    {{#each posts as |post|}}
       {{post.title}}
       {{post.excerpt}}
     {{/each}}
@@ -100,7 +100,7 @@ Multiple `dataActions` can be passed with the `hash` helper or the included `to-
 
 ### Using the yielded `tri` and `action` objects
 
-The `tri` object contains the component name, data, and state for each of the three possible states: 'loading', 'error', 'success'. By accessing the 'component' property of a given state you can define what you want to render in your template when that state is active (see examples above). The 'data' property gives you access to the data returned from your data request.
+The `tri` object contains the component name, and state for each of the three possible states: 'loading', 'error', 'success'. By accessing the 'component' property of a given state you can define what you want to render in your template when that state is active (see examples above). Appropriate data is piped directly into whichever component is being yielded through a `data` attribute.
 
 Behind the scenes we use the amazing [ember-concurrency](http://ember-concurrency.com/) addon to perform the requests which gives us the ability to restart or cancel requests in case the component is destroyed before the request has finished.
 

--- a/addon/templates/components/tri-state.hbs
+++ b/addon/templates/components/tri-state.hbs
@@ -1,18 +1,15 @@
 {{yield
   (hash
     error=(hash
-      component=(component state.error.component)
-      data=state.error.data
+      component=(component state.error.component data=state.error.data)
       isActive=state.error.isActive
     )
     success=(hash
-      component=(component state.success.component)
-      data=state.success.data
+      component=(component state.success.component data=state.success.data)
       isActive=state.success.isActive
     )
     loading=(hash
       component=(component state.loading.component)
-      data=state.loading.data
       isActive=state.loading.isActive
     )
   )

--- a/addon/templates/components/tri-yield.hbs
+++ b/addon/templates/components/tri-yield.hbs
@@ -1,1 +1,1 @@
-{{yield}}
+{{yield data}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -18,14 +18,14 @@
     {{/tri-loading}}
   {{/tri.loading.component}}
 
-  {{#tri.error.component}}
+  {{#tri.error.component as |error|}}
     {{#tri-error}}
-      {{tri.error.data.error}}
+      {{error}}
     {{/tri-error}}
   {{/tri.error.component}}
 
-  {{#tri.success.component}}
-    {{#tri-success user=tri.success.data.user events=tri.success.data.events as |user events|}}
+  {{#tri.success.component as |data|}}
+    {{#tri-success user=data.user events=data.events as |user events|}}
       {{if tri.loading.isActive 'Updating...'}}
       <p>User: {{user.name}} | Last updated: {{user.time}}</p>
       <p>Events</p>

--- a/tests/integration/components/tri-yield-test.js
+++ b/tests/integration/components/tri-yield-test.js
@@ -2,20 +2,19 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('tri-yield', 'Integration | Component | tri yield', {
-  integration: true
+  integration: true,
 });
 
-test('it renders', function(assert) {
-  this.render(hbs`{{tri-yield}}`);
+test('it yields its data attribute', function(assert) {
+  this.render(hbs`{{tri-yield data="foo"}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(this.$().text().trim(), '', 'it does not output anything');
 
-  // Template block usage:
   this.render(hbs`
-    {{#tri-yield}}
-      template block text
+    {{#tri-yield data="foo" as |data|}}
+      {{data}}
     {{/tri-yield}}
   `);
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(this.$().text().trim(), 'foo', 'it yields `foo`');
 });


### PR DESCRIPTION
Providing data directly to the yielded component shrinks the mental
overhead consuming app authors need to take into account. It also
increases flexibility and allows authors to rename the yielded data
which is useful for maintaining context in the template.