### PR TITLE
Fix binding issue with setup and teardown logic

### DIFF
--- a/addon/components/tri-state.js
+++ b/addon/components/tri-state.js
@@ -148,8 +148,10 @@ export default Component.extend({
 
     // If we want to allow for outside sources to take action, set up event listeners
     if (this.listenForEvents) {
-      this.get('triEvents').on('update', this._updateData.bind(this));
-      this.get('triEvents').on('flush', this._flushData.bind(this));
+      this._updateData = this._updateData.bind(this);
+      this._flushData = this._flushData.bind(this);
+      this.get('triEvents').on('update', this._updateData);
+      this.get('triEvents').on('flush', this._flushData);
     }
 
     // Fetch data once we have the `dataActions`


### PR DESCRIPTION
Bind in JavaScript creates a new function so there was no way to remove
update or flush from the triEvents service after it was added. This was
causing errors complaining about set on a destroyed object.